### PR TITLE
Pass a default {} to before_action to prevent exception

### DIFF
--- a/lib/rails_nestable_layouts.rb
+++ b/lib/rails_nestable_layouts.rb
@@ -10,6 +10,7 @@ module RailsNestableLayouts
       if args.last.is_a?(Hash)
         opts = args.pop
       end
+      opts ||= {}
 
       if args.first.is_a?(Array)
         layouts = args.first

--- a/lib/rails_nestable_layouts/version.rb
+++ b/lib/rails_nestable_layouts/version.rb
@@ -1,3 +1,3 @@
 module RailsNestableLayouts
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
With only a layout `nested_layouts 'layouts/dashboard/base'` and no other argument I got the error that the method `before` is undefined. With `nested_layouts 'layouts/dashboard/base', {}` it did work fine